### PR TITLE
fixup-mountpoints: add all partitions

### DIFF
--- a/fixup-mountpoints
+++ b/fixup-mountpoints
@@ -809,22 +809,81 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/xblbak sdc1 ' \
             "$@"
         ;;
+        
     "enchilada")
         sed -i \
+            -e 's block/bootdevice/by-name/ALIGN_TO_128K_1 sdd1 ' \
+            -e 's block/bootdevice/by-name/ALIGN_TO_128K_2 sdf1 ' \
+            -e 's block/bootdevice/by-name/ImageFv sde72 ' \
+            -e 's block/bootdevice/by-name/LOGO sde20 ' \
+            -e 's block/bootdevice/by-name/abl sde8 ' \
+            -e 's block/bootdevice/by-name/aop sde1 ' \
+            -e 's block/bootdevice/by-name/apdp sde63 ' \
             -e 's block/bootdevice/by-name/bluetooth sde5 ' \
             -e 's block/bootdevice/by-name/boot sde11 ' \
+            -e 's block/bootdevice/by-name/bootging sde58 ' \
+            -e 's block/bootdevice/by-name/cdt sdd2 ' \
+            -e 's block/bootdevice/by-name/cmnlib64 sde13 ' \
+            -e 's block/bootdevice/by-name/cmnlib sde12 ' \
+            -e 's block/bootdevice/by-name/config sda12 ' \
+            -e 's block/bootdevice/by-name/ddr sdd3 ' \
+            -e 's block/bootdevice/by-name/devcfg sde14 ' \
+            -e 's block/bootdevice/by-name/devinfo sde61 ' \
+            -e 's block/bootdevice/by-name/dip sde62 ' \
             -e 's block/bootdevice/by-name/dsp sde9 ' \
+            -e 's block/bootdevice/by-name/dtbo sde18 ' \
+            -e 's block/bootdevice/by-name/frp sda6 ' \
+            -e 's block/bootdevice/by-name/fsc sdf5 ' \
+            -e 's block/bootdevice/by-name/fsg sdf4 ' \
+            -e 's block/bootdevice/by-name/fw_4j1ed sde21 ' \
+            -e 's block/bootdevice/by-name/fw_4u1ea sde22 ' \
+            -e 's block/bootdevice/by-name/fw_ufs3 sde23 ' \
+            -e 's block/bootdevice/by-name/fw_ufs4 sde24 ' \
+            -e 's block/bootdevice/by-name/fw_ufs5 sde25 ' \
+            -e 's block/bootdevice/by-name/fw_ufs6 sde26 ' \
+            -e 's block/bootdevice/by-name/fw_ufs7 sde27 ' \
+            -e 's block/bootdevice/by-name/fw_ufs8 sde28 ' \
+            -e 's block/bootdevice/by-name/hyp sde3 ' \
+            -e 's block/bootdevice/by-name/keymaster sde10 ' \
+            -e 's block/bootdevice/by-name/keystore sda5 ' \
+            -e 's block/bootdevice/by-name/limits sde67 ' \
+            -e 's block/bootdevice/by-name/logdump sde71 ' \
+            -e 's block/bootdevice/by-name/logfs sde69 ' \
+            -e 's block/bootdevice/by-name/mdtp sde7 ' \
+            -e 's block/bootdevice/by-name/mdtpsecapp sde6 ' \
+            -e 's block/bootdevice/by-name/minidump sde57 ' \
             -e 's block/bootdevice/by-name/misc sda3 ' \
             -e 's block/bootdevice/by-name/modem sde4 ' \
+            -e 's block/bootdevice/by-name/modemst1 sdf2 ' \
+            -e 's block/bootdevice/by-name/modemst2 sdf3 ' \
+            -e 's block/bootdevice/by-name/msadp sde64 ' \
             -e 's block/bootdevice/by-name/odm sda15 ' \
+            -e 's block/bootdevice/by-name/oem_dycnvbk sda8 ' \
+            -e 's block/bootdevice/by-name/oem_stanvbk sda9 ' \
+            -e 's block/bootdevice/by-name/op1 sde59 ' \
+            -e 's block/bootdevice/by-name/op2 sda7 ' \
+            -e 's block/bootdevice/by-name/param sda4 ' \
             -e 's block/bootdevice/by-name/persist sda2 ' \
+            -e 's block/bootdevice/by-name/qupfw sde15 ' \
+            -e 's block/bootdevice/by-name/reserve1 sda10 ' \
+            -e 's block/bootdevice/by-name/reserve2 sda11 ' \
+            -e 's block/bootdevice/by-name/sec sde60 ' \
+            -e 's block/bootdevice/by-name/splash sde66 ' \
+            -e 's block/bootdevice/by-name/spunvm sde65 ' \
+            -e 's block/bootdevice/by-name/ssd sda1 ' \
+            -e 's block/bootdevice/by-name/sti sde70 ' \
+            -e 's block/bootdevice/by-name/storsec sde19 ' \
             -e 's block/bootdevice/by-name/system sda13 ' \
+            -e 's block/bootdevice/by-name/toolsfv sde68 ' \
+            -e 's block/bootdevice/by-name/tz sde2 ' \
             -e 's block/bootdevice/by-name/userdata sda17 ' \
             -e 's block/bootdevice/by-name/vbmeta sde17 ' \
             -e 's block/bootdevice/by-name/vendor sde16 ' \
+            -e 's block/bootdevice/by-name/xbl sdb1 ' \
+            -e 's block/bootdevice/by-name/xbl_config sdb2 ' \
             "$@"
         ;;
-
+        
     "bacon")
         sed -i \
             -e 's block/platform/msm_sdcc.1/by-name/modem mmcblk0p1 ' \


### PR DESCRIPTION
Some partitions like logdump/minidump and others might be useful for diagnosis.